### PR TITLE
fixed username already exists issue

### DIFF
--- a/app/src/main/java/org/aossie/agoraandroid/signUp/SignUpActivity.java
+++ b/app/src/main/java/org/aossie/agoraandroid/signUp/SignUpActivity.java
@@ -76,11 +76,15 @@ public class SignUpActivity extends AppCompatActivity {
                     mPasswordEditText.setError("Please enter password");
                 } else {
                     mPasswordEditText.setError(null);
-                    signUpViewModel.signUpRequest(userName, userPass, userEmail, firstName, lastName, securityQuestion, securityQuestionAnswer);
+                    //signUpViewModel.signUpRequest(userName, userPass, userEmail, firstName, lastName, securityQuestion, securityQuestionAnswer);
                 }
+
+                if(!(userName.isEmpty()) && !(firstName.isEmpty()) && !(lastName.isEmpty()) && !(userEmail.isEmpty()) && !(securityQuestionAnswer.isEmpty()) && !(userPass.isEmpty()))
+                    signUpViewModel.signUpRequest(userName, userPass, userEmail, firstName, lastName, securityQuestion, securityQuestionAnswer);
 
             }
         });
+
         final ArrayAdapter <CharSequence> adapter = ArrayAdapter.createFromResource(this,R.array.security_questions,android.R.layout.simple_spinner_item);
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         appCompatSpinner.setAdapter(adapter);

--- a/app/src/main/java/org/aossie/agoraandroid/signUp/SignUpViewModel.java
+++ b/app/src/main/java/org/aossie/agoraandroid/signUp/SignUpViewModel.java
@@ -4,11 +4,14 @@ package org.aossie.agoraandroid.signUp;
 import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
+import android.widget.EditText;
 import android.widget.Toast;
 
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
+
+import com.google.android.material.textfield.TextInputLayout;
 
 import net.steamcrafted.loadtoast.LoadToast;
 
@@ -25,6 +28,7 @@ import retrofit2.Response;
 class SignUpViewModel extends AndroidViewModel {
     private final Context context;
     private LoadToast loadToast;
+    private TextInputLayout mUserNameEditText;
 
     public SignUpViewModel(@NonNull Application application, Context context) {
         super(application);
@@ -68,7 +72,7 @@ class SignUpViewModel extends AndroidViewModel {
                     context.startActivity(new Intent(context, LogInActivity.class));
                 } else if (response.code() == 409) {
                     loadToast.error();
-                    Toast.makeText(getApplication(), "User With Same UserName already Exists", Toast.LENGTH_LONG).show();
+                    Toast.makeText(getApplication(), "User with same Email or Username already exists", Toast.LENGTH_LONG).show();
                 } else {
                     loadToast.error();
                     Toast.makeText(getApplication(), "Something went wrong please try again", Toast.LENGTH_LONG).show();


### PR DESCRIPTION
In Reference to #2 

**Problem** - Even if your username editText is empty it was showing username already exists.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/44394901/73087367-6c6b3c00-3ef8-11ea-9c92-eb56436b7753.gif)

**Solution** - 
1. Firstly if any of the field is empty the activity shouldn't connect to the back-end. It should show error there itself.
2. The Toast saying "User With Same UserName already Exists" is not fully correct. Actually even if the email already exists it will show the same toast, which i corrected to "User with same Email or Username already exists".
3. First it will check if all fields are not empty, only then it will try to connect with back-end.

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/44394901/73088777-e1d80c00-3efa-11ea-93e2-e03e44e1fc3a.gif)

In the above gif the username and email were both already registered. First i changed the email and then the username. Finally it was a successful sign up.